### PR TITLE
chore: Fix govulncheck vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
-FROM golang:1.20 as builder
+FROM --platform=linux/amd64 golang:1.22.2 as builder
 
 RUN apt-get update && \
     apt-get install git ca-certificates gcc -y && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mimiro.io/kafka-datalayer/kafka-datalayer
 
-go 1.19
+go 1.22.2
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0
@@ -80,12 +80,12 @@ require (
 	go.uber.org/dig v1.17.0 // indirect
 	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpz
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
+github.com/Microsoft/hcsshim v0.9.7/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/actgardner/gogen-avro/v10 v10.1.0/go.mod h1:o+ybmVjEa27AAr35FRqU98DJu1fXES56uXniYFv4yDA=
 github.com/actgardner/gogen-avro/v10 v10.2.1/go.mod h1:QUhjeHPchheYmMDni/Nx7VB0RsT/ee8YIgGY/xpEQgQ=
 github.com/actgardner/gogen-avro/v9 v9.1.0/go.mod h1:nyTj6wPqDJoxM3qdnjcLv+EnMDSDFqE0qDpva2QRmKc=
@@ -57,6 +58,7 @@ github.com/bamzi/jobrunner v1.0.0/go.mod h1:ZNk2RGqvkuB9747EVGeyyAdCiS2VKi2KBznD
 github.com/bcicen/jstream v1.0.1 h1:BXY7Cu4rdmc0rhyTVyT3UkxAiX3bnLpKLas9btbH5ck=
 github.com/bcicen/jstream v1.0.1/go.mod h1:9ielPxqFry7Y4Tg3j4BfjPocfJ3TbsRtXOAYXYmRuAQ=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
@@ -82,10 +84,12 @@ github.com/confluentinc/confluent-kafka-go v1.9.2/go.mod h1:ptXNqsuDfYbAE/LBW6pn
 github.com/containerd/containerd v1.6.19 h1:F0qgQPrG0P2JPgwpxWxYavrVeXAG0ezUIB9Z/4FTUAU=
 github.com/containerd/containerd v1.6.19/go.mod h1:HZCDMn4v/Xl2579/MvtOC2M206i+JJ6VxFWU/NetrGY=
 github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
+github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -112,6 +116,7 @@ github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03D
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.14.0/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09mUdL/ijj8og=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -178,6 +183,7 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -242,6 +248,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -312,6 +319,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.1 h1:HNLA3HtUIROrQwG1cuu5EYuqk3UEoJ61Dr/9xkd6sok=
 github.com/santhosh-tekuri/jsonschema/v5 v5.0.1/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
@@ -406,8 +414,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -481,8 +489,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -558,8 +566,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
@@ -574,8 +582,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
-golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -749,6 +757,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v1 v1.0.0/go.mod h1:CxwszS/Xz1C49Ucd2i6Zil5UToP1EmyrFhKaMVbg1mk=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/httprequest.v1 v1.2.1/go.mod h1:x2Otw96yda5+8+6ZeWwHIJTFkEHWP/qP8pJOzqEtWPM=
@@ -765,6 +774,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Fixes
```
Scanning your code and 384 packages across 62 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.17.0
    Fixed in: golang.org/x/net@v0.23.0
    Example traces found:
      #1: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.ConnectionError.Error
      #2: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.ErrCode.String
      #3: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.FrameHeader.String
      #4: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.FrameType.String
      #5: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.GoAwayError.Error
      #6: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.Setting.String
      #7: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.SettingID.String
      #8: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.StreamError.Error
      #9: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http2.chunkWriter.Write
      #10: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.connError.Error
      #11: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.duplicatePseudoHeaderError.Error
      #12: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http2.gzipReader.Close
      #13: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http2.gzipReader.Read
      #14: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.headerFieldNameError.Error
      #15: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.headerFieldValueError.Error
      #16: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http2.pseudoHeaderError.Error
      #17: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http2.stickyErrWriter.Write
      #18: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http2.transportResponseBody.Close
      #19: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http2.transportResponseBody.Read
      #20: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http2.writeData.String

  Standard library
    Found in: net/http@go1.22.1
    Fixed in: net/http@go1.22.2
    Example traces found:
      #1: internal/kafka/consumer.go:193:15: kafka.Consumers.ChangeSet calls signal.Notify, which eventually calls http.CanonicalHeaderKey
      #2: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.Client.Do
      #3: internal/web/middlewares/auth0.go:68:24: middlewares.newCache calls http.Get
      #4: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.Header.Add
      #5: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.Header.Del
      #6: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.Header.Get
      #7: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.Header.Set
      #8: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.NewRequest
      #9: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.Request.FormValue
      #10: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.Request.Referer
      #11: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.Request.SetBasicAuth
      #12: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.Request.UserAgent
      #13: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.body.Close
      #14: internal/coder/parser.go:9:31: coder.ParseStream calls jstream.NewDecoder, which eventually calls http.body.Read
      #15: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.bodyEOFSignal.Close
      #16: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.bodyEOFSignal.Read
      #17: internal/conf/config.go:64:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.bodyLocked.Read
      #18: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.bufioFlushWriter.Write
      #19: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.cancelTimerBody.Close
      #20: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.cancelTimerBody.Read
      #21: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.checkConnErrorWriter.Write
      #22: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.chunkWriter.Write
      #23: internal/conf/config.go:64:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.connReader.Read
      #24: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.expectContinueReader.Close
      #25: internal/coder/parser.go:9:31: coder.ParseStream calls jstream.NewDecoder, which eventually calls http.expectContinueReader.Read
      #26: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.gzipReader.Close
      #27: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.gzipReader.Read
      #28: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2ConnectionError.Error
      #29: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2ErrCode.String
      #30: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2FrameHeader.String
      #31: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2FrameType.String
      #32: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2FrameWriteRequest.String
      #33: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2GoAwayError.Error
      #34: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2Setting.String
      #35: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2SettingID.String
      #36: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2StreamError.Error
      #37: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.http2chunkWriter.Write
      #38: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2connError.Error
      #39: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2duplicatePseudoHeaderError.Error
      #40: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.http2gzipReader.Close
      #41: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.http2gzipReader.Read
      #42: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2headerFieldNameError.Error
      #43: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2headerFieldValueError.Error
      #44: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.http2pseudoHeaderError.Error
      #45: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.http2requestBody.Close
      #46: internal/coder/parser.go:9:31: coder.ParseStream calls jstream.NewDecoder, which eventually calls http.http2requestBody.Read
      #47: internal/web/consumerhandler.go:79:22: web.consume calls echo.Response.Flush, which calls http.http2responseWriter.Flush
      #48: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which calls http.http2responseWriter.Write
      #49: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.http2responseWriter.WriteHeader
      #50: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.http2responseWriter.WriteString
      #51: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.http2stickyErrWriter.Write
      #52: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.http2transportResponseBody.Close
      #53: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.http2transportResponseBody.Read
      #54: internal/kafka/consumer.go:122:14: kafka.Consumers.ChangeSet calls fmt.Sprintf, which eventually calls http.http2writeData.String
      #55: internal/conf/config.go:64:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.loggingConn.Read
      #56: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.loggingConn.Write
      #57: internal/conf/config.go:64:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.maxBytesReader.Read
      #58: internal/kafka/consumer.go:193:15: kafka.Consumers.ChangeSet calls signal.Notify, which eventually calls http.onceCloseListener.Close
      #59: internal/coder/parser.go:9:31: coder.ParseStream calls jstream.NewDecoder, which eventually calls http.persistConn.Read
      #60: internal/kafka/producer.go:115:28: kafka.Producers.ProduceEntities calls json.Marshal, which eventually calls http.persistConnWriter.ReadFrom
      #61: internal/conf/manager.go:64:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.persistConnWriter.Write
      #62: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.readTrackingBody.Close
      #63: internal/coder/parser.go:9:31: coder.ParseStream calls jstream.NewDecoder, which eventually calls http.readTrackingBody.Read
      #64: internal/coder/decoder.go:70:37: coder.AvroDecoder.Decode calls srclient.SchemaRegistryClient.GetSchema, which eventually calls http.readWriteCloserBody.Read
      #65: internal/web/consumerhandler.go:79:22: web.consume calls echo.Response.Flush, which calls http.response.Flush
      #66: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which calls http.response.Write
      #67: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.response.WriteHeader
      #68: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.response.WriteString
      #69: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which calls http.timeoutWriter.Write
      #70: internal/web/consumerhandler.go:77:22: web.consume calls echo.Response.Write, which eventually calls http.timeoutWriter.WriteHeader
      #71: internal/conf/manager.go:84:77: conf.ConfigurationManager.load calls http.transportReadFromServerError.Error

Your code is affected by 1 vulnerability from the Go standard library.
```